### PR TITLE
Add Get URLVariables

### DIFF
--- a/Swift/AEPSampleApp/EdgeIdentityView.swift
+++ b/Swift/AEPSampleApp/EdgeIdentityView.swift
@@ -18,6 +18,7 @@ struct EdgeIdentityView: View {
     @State var adID: UUID?
     @State var adIdText: String = ""
     @State var trackingAuthorizationResultText: String = ""
+    @State var urlVariablesText: String = ""
     
     /// Updates view for ad ID related elements
     func setDeviceAdvertisingIdentifier() {
@@ -39,15 +40,16 @@ struct EdgeIdentityView: View {
     var body: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: 12) {
+                Text("Current ECID:")
                 Button(action: {
                     Identity.getExperienceCloudId { ecid, error in
                         currentEcid = ecid ?? ""
                     }
                     
                 }) {
+                    
                     Text("Get ExperienceCloudId")
                 }.buttonStyle(CustomButtonStyle())
-                Text("Current ECID:")
                 Text(currentEcid)
                     .lineLimit(1)
                     .minimumScaleFactor(0.5)
@@ -59,6 +61,7 @@ struct EdgeIdentityView: View {
                             }
                     }
                 
+                Text("Current Identities:")
                 Button(action: {
                     Identity.getIdentities { identityMap, error in
                         currentIdentityMap = identityMap
@@ -68,7 +71,6 @@ struct EdgeIdentityView: View {
                     Text("Get Identities")
                 }.buttonStyle(CustomButtonStyle())
                 
-                Text("Current Identities:")
                 Text(currentIdentityMap?.jsonString ?? "")
                     .fixedSize(horizontal: false, vertical: true)
                 
@@ -125,6 +127,23 @@ struct EdgeIdentityView: View {
                             Text("Set ad ID as empty string")
                         }.buttonStyle(CustomButtonStyle())
                     }
+                }
+                
+                VStack(alignment: .leading, spacing: 12) {
+                    
+                    Text("Get URLVariables:")
+                    Button(action: {
+                        self.urlVariablesText = ""
+
+                        AEPEdgeIdentity.Identity.getUrlVariables { urlVariablesString, _ in
+                            self.urlVariablesText = urlVariablesString ?? "URLVariables not generated"
+                        }
+                        
+                    }) {
+                        Text("Get URLVariables")
+                    }.buttonStyle(CustomButtonStyle())
+                    
+                    Text(urlVariablesText)
                 }
             }.padding()
         }


### PR DESCRIPTION
Add Get URLVariables to the Edge Identity View.
Rearrange the content labels.

<!--- Provide a general summary of your changes in the Title above -->

## Description

![URLVarialbes](https://user-images.githubusercontent.com/29806547/172281594-2f53b5b4-c4e7-45ba-82c8-0d7a78352540.png)


![Getview](https://user-images.githubusercontent.com/29806547/172282388-72d0337e-b81f-413b-8d5e-62d9394f2ced.png)


## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
